### PR TITLE
clang-cross: workaround missing clang-native when using sstate cache

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -35,7 +35,7 @@ OVERRIDES[vardepsexclude] += "TOOLCHAIN"
 def clang_dep_prepend(d):
     if not d.getVar('INHIBIT_DEFAULT_DEPS', False):
         if not oe.utils.inherits(d, 'allarch') :
-            return " clang-cross-${TARGET_ARCH} compiler-rt libcxx"
+            return " clang-cross-${TARGET_ARCH} clang-native compiler-rt libcxx"
     return ""
 
 BASEDEPENDS_remove_toolchain-clang_class-target = "virtual/${TARGET_PREFIX}gcc"


### PR DESCRIPTION
For some reason on Yocto 2.1 clang-native is not installed into sysroot
when clang-cross-${TARGET_ARCH} is installed, although it's marked as
its dependency via DEPENDS variable. On OE master it works as expected.

A long term goal would be to determine why it doesn't work as expected
and provide a real fix.