### PR TITLE
Fixes for flutter and chromium

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -64,7 +64,8 @@ OVERRIDES[vardepsexclude] += "TOOLCHAIN"
 def clang_dep_prepend(d):
     if not d.getVar('INHIBIT_DEFAULT_DEPS', False):
         if not oe.utils.inherits(d, 'allarch') :
-            return " clang-cross-${TARGET_ARCH} compiler-rt libcxx"
+            libcxx = " libcxx" if "libc++" in d.getVar("LIBCPLUSPLUS") else ""
+            return " clang-cross-${TARGET_ARCH} clang-native compiler-rt" + libcxx
     return ""
 
 BASEDEPENDS_remove_toolchain-clang_class-target = "virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}compilerlibs"

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -163,7 +163,7 @@ do_install() {
 }
 
 do_install_append_class-native () {
-	install -Dm 0755 ${B}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
+	install -Dm 0755 ${B}/NATIVE/bin/clang-tblgen ${D}${bindir}/clang-tblgen
 	install -Dm 0755 ${B}/tools/clang/stage2-bins/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
 	for f in `find ${D}${bindir} -executable -type f -not -type l`; do
 		test -n "`file $f|grep -i ELF`" && ${STRIP} $f
@@ -172,8 +172,8 @@ do_install_append_class-native () {
 }
 
 do_install_append_class-nativesdk () {
-	install -Dm 0755 ${B}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
-	install -Dm 0755 ${B}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
+	install -Dm 0755 ${B}/NATIVE/bin/clang-tblgen ${D}${bindir}/clang-tblgen
+	install -Dm 0755 ${B}/tools/clang/stage2-bins/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
 	for f in `find ${D}${bindir} -executable -type f -not -type l`; do
 		test -n "`file $f|grep -i ELF`" && ${STRIP} $f
 	done


### PR DESCRIPTION
commit b6c1edf8e73a5fced0596fb3ca0ae708b38bd825 (HEAD -> morty-clang-9, origin/dw-5)
Author: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
Date:   Wed Sep 11 14:01:16 2019 +0200

    Fix installation of clang-tblgen and lldb-tblgen
    
    Fixes:
    
    | install: cannot stat ‘/data/dwrobel1/onemw/onemw/oe-builds/chromium-3/onemw/build-brcm97449svms-refboard/tmp/work/x86_64-linux/clang-native/9.0.0-r0/build/bin/clang-tblgen’: No such file or directory
    | WARNING: /data/dwrobel1/onemw/onemw/oe-builds/chromium-3/onemw/build-brcm97449svms-refboard/tmp/work/x86_64-linux/clang-native/9.0.0-r0/temp/run.do_install.25108:1 exit 1 from 'install -Dm 0755 /data/dwrobel1/onemw/onemw/oe-builds/chromium-3/onemw/build-brcm97449svms-refboard/tmp/work/x86_64-linux/clang-native/9.0.0-r0/build/bin/clang-tblgen /data/dwrobel1/onemw/onemw/oe-builds/chromium-3/onemw/build-brcm97449svms-refboard/tmp/work/x86_64-linux/clang-native/9.0.0-r0/image/data/dwrobel1/onemw/onemw/oe-builds/chromium-3/onemw/build-brcm97449svms-refboard/tmp/sysroots/x86_64-linux/usr/bin/clang-tblgen'
    
    $ cat /etc/redhat-release
    CentOS Linux release 7.5.1804 (Core)
    
    The location of the tools is as following:
    $ pwd
    /data/dwrobel1/onemw/onemw/oe-builds/chromium-3/onemw/build-brcm97449svms-refboard/tmp/work/x86_64-linux/clang-native/9.0.0-r0/build
    $ find . -name clang-tblgen
    ./tools/clang/stage2-bins/bin/clang-tblgen
    ./tools/clang/stage2-bins/NATIVE/bin/clang-tblgen
    ./NATIVE/bin/clang-tblgen
    $ find . -name lldb-tblgen
    ./tools/clang/stage2-bins/bin/lldb-tblgen
    ./tools/clang/stage2-bins/NATIVE/bin/lldb-tblgen

commit 2a013a22fc7ac27ceb19137796b7b9ef30c0d8ed
Author: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
Date:   Wed Sep 11 14:01:01 2019 +0200

    Remove libcxx from deps if it's not used
